### PR TITLE
[Openthermgateway] Improve robustness and compatibility

### DIFF
--- a/addons/binding/org.openhab.binding.openthermgateway/ESH-INF/config/config.xml
+++ b/addons/binding/org.openhab.binding.openthermgateway/ESH-INF/config/config.xml
@@ -9,35 +9,23 @@
             <description>Connection settings.</description>
         </parameter-group>
 
-        <!-- 
-        <parameter-group name="otgw">
-            <label>OpenTherm Gateway</label>
-            <description>OpenTherm Gateway settings.</description>
-        </parameter-group>
-        -->
-        
         <parameter name="ipaddress" type="text" required="true" groupName="connection">
 		    <label>Hostname or IP address</label>
 		    <description>The hostname or IP address to connect to the OpenTherm Gateway.</description>
+		    <context>network-address</context>
 		</parameter>
 		
-		<parameter name="port" type="integer" required="true" groupName="connection">
+		<parameter name="port" type="integer" required="true" groupName="connection" min="0" max="65535">
 		    <label>Port</label>
 		    <description>The port used to connect to the OpenTherm Gateway.</description>
 		</parameter>				
 		
-        <!-- 
-        <parameter name="setpointcommand" type="text" required="true" groupName="otgw">
-            <label>Setpoint command</label>
-            <description>The command used to override the room temperature setpoint.</description>
-            <default>TT</default>
-            <options>
-                <option value="TT">Temperature Temporary (TT)</option>
-                <option value="TC">Temperature Constant (TC)</option>
-            </options>
-        </parameter>
-        -->
-        		 
+        <parameter name="connectionRetryInterval" type="integer" required="true" groupName="connection" min="1" unit="s">
+            <label>Connection Retry Interval</label>
+            <description>The interval in seconds to retry connecting.</description>
+            <default>60</default>
+        </parameter>                
+        
     </config-description>
 
 </config-description:config-descriptions>

--- a/addons/binding/org.openhab.binding.openthermgateway/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.openthermgateway/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Export-Package:
  org.openhab.binding.openthermgateway.handler
 Import-Package: 
  com.google.common.collect,
+ javax.measure.quantity,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,

--- a/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
+++ b/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
@@ -160,6 +160,8 @@ public class OpenThermGatewayHandler extends BaseThingHandler implements OpenThe
     @Override
     public void log(LogLevel loglevel, String message, Throwable t) {
         switch (loglevel) {
+            case Trace:
+                logger.trace(message, t);
             case Debug:
                 logger.debug(message, t);
                 break;
@@ -180,6 +182,9 @@ public class OpenThermGatewayHandler extends BaseThingHandler implements OpenThe
     @Override
     public void log(LogLevel loglevel, String message) {
         switch (loglevel) {
+            case Trace:
+                logger.trace(message);
+                break;
             case Debug:
                 logger.debug(message);
                 break;

--- a/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
+++ b/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/handler/OpenThermGatewayHandler.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -77,7 +78,13 @@ public class OpenThermGatewayHandler extends BaseThingHandler implements OpenThe
                 String channel = channelUID.getId();
                 String code = getGatewayCodeFromChannel(channel);
 
-                GatewayCommand gatewayCommand = GatewayCommand.parse(code, command.toFullString());
+                GatewayCommand gatewayCommand;
+                if (command instanceof QuantityType) {
+                    gatewayCommand = GatewayCommand.parse(code,
+                            Double.toString(((QuantityType) command).doubleValue()));
+                } else {
+                    gatewayCommand = GatewayCommand.parse(code, command.toFullString());
+                }
 
                 if (gatewayCommand != null && checkConnection()) {
                     connector.sendCommand(gatewayCommand);

--- a/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/LogLevel.java
+++ b/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/LogLevel.java
@@ -1,6 +1,7 @@
 package org.openhab.binding.openthermgateway.internal;
 
 public enum LogLevel {
+    Trace,
     Debug,
     Info,
     Error,

--- a/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayConfiguration.java
+++ b/addons/binding/org.openhab.binding.openthermgateway/src/main/java/org/openhab/binding/openthermgateway/internal/OpenThermGatewayConfiguration.java
@@ -22,4 +22,6 @@ public class OpenThermGatewayConfiguration {
     public String ipaddress;
 
     public int port;
+
+    public int connectionRetryInterval;
 }


### PR DESCRIPTION
Improve robustness and compatibility

Changed message filtering to also allow roomtemp messages that receive
invalid dataid response
Added Trace level debug info
Added disconnect detection and automatic reconnect

These changes should improve robustness of the connection.
Also it allows on my system to read the room temperature (it failed originally because my boiler answers with Inavlid-Data on the Write RoomTemp command from the thermostat).

Signed-off-by: Arjan Mels <arjan.mels@gmx.net>